### PR TITLE
Fixes "incompatible integer to pointer conversion" on macos

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -4,11 +4,10 @@
   "description": "pkg-config packaged for esy",
   "source": "https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz#sha256:6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591",
   "override": {
-    "buildEnv": {},
     "build": [
       "bash -c 'patch -p1 < glib-format-errors.patch'",
       "find ./ -exec touch -t 200905010101 {} +",
-      "./configure --disable-debug --prefix=#{self.install} --disable-host-tool --with-internal-glib #{os == 'windows'? '--host x86_64-W64-mingw32': ''}",
+      "./configure --disable-debug --prefix=#{self.install} --disable-host-tool --with-internal-glib #{os == 'windows'? '--host x86_64-W64-mingw32': ''} CFLAGS=-Wno-int-conversion",
       "make -j8"
     ],
     "install": "make install",


### PR DESCRIPTION
For build issue with Xcode 15.3
https://gitlab.freedesktop.org/pkg-config/pkg-config/-/issues/81

Error was,
```
gatomic.c:392:10: error: incompatible integer to pointer conversion passing 'gssize' (aka 'long') to parameter of type 'gpointer' (aka 'void *') [-Wint-c
```